### PR TITLE
Feature: Adding support for TLSV1.2

### DIFF
--- a/src/conekta/conekta/Base/Requestor.cs
+++ b/src/conekta/conekta/Base/Requestor.cs
@@ -29,6 +29,7 @@ namespace conekta
 			}
 
 			try {
+				ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 				var uname = Environment.OSVersion;
 				HttpWebRequest http = (HttpWebRequest)WebRequest.Create(conekta.Api.baseUri + resource_uri);
 				http.Accept = "application/vnd.conekta-v" + conekta.Api.version + "+json";


### PR DESCRIPTION
**Why is this change neccesary?**
in order to have compliance with the latest security standards to keep communication our libraries wiht our api
**How does it address the issue?***
forcing to curl library to set up tls v1.2 as mandatory
**What side effects does this change have?**
nothing
resource
https://community.developer.visa.com/t5/Developer-Tools/Upgrade-to-TLS-1-2-Let-security-be-part-of-your-development/ba-p/6691