### PR TITLE
Feature: Add reference parameter to .Net SDK

### DIFF
--- a/src/conekta/conekta/Test.cs
+++ b/src/conekta/conekta/Test.cs
@@ -867,6 +867,36 @@ namespace ConektaTest
         }
 
         [Test()]
+        [Ignore("Not ready yet")]
+        public void createCustomerWithCustomReference()
+        {
+            getApiKey();
+            conekta.Api.version = "2.0.0";
+
+            Customer customer = new conekta.Customer().create(@"{
+                  ""name"": ""Emiliano Cabrera"",
+                  ""phone"": ""+5215544443333"",
+                  ""email"": ""user@example.com"",
+                  ""corporate"": true,
+                  ""payment_sources"": [{
+                    ""expires_at"": 1553273553,
+                    ""type"": ""oxxo_recurrent"",
+                    ""reference"": ""5512345678""
+                  }]
+                  }");
+
+            PaymentSource paymentSource = customer.payment_sources[0];
+            OfflineRecurrentReference reference = paymentSource as OfflineRecurrentReference;
+
+            Assert.IsNotNull(reference.reference);
+            Assert.IsNotNull(reference.provider);
+            Assert.AreEqual(reference.expires_at, "1553273553");
+            Assert.AreEqual(reference.reference.Length, 10);
+            Assert.AreEqual(reference.reference, "5512345678");
+
+        }
+
+        [Test()]
         public void createCustomerWithCard()
         {
             getApiKey();


### PR DESCRIPTION
#### Why is this change necessary?

Payments API currently is taking custom fixed references from merchants
customer create request

#### How does it address the issue?

It's necessary to test that the custom reference is not created by
Conekta when the customer sends the reference in a request

#### What side effects does this have?

Tests related to this feature are skipped because none of the merchants
have offline recurrent identifier which is needed to test this
feature