### PR TITLE
Order cancel method creation for Oxxo charges

### DIFF
--- a/src/conekta/IOrderContext.cs
+++ b/src/conekta/IOrderContext.cs
@@ -45,6 +45,14 @@ namespace Conekta
     /// <returns>The capture.</returns>
     /// <param name="orderId">Order identifier.</param>
     Task<Order> CaptureAsync(string orderId);
+    
+    /// <summary>
+    /// Cancel the specified orderId.
+    /// (For Oxxo payments only)
+    /// </summary>
+    /// <returns>The canceled order.</returns>
+    /// <param name="orderId">Order identifier.</param>
+    Task<Order> CancelAsync(string orderId);
 
     /// <summary>
     /// Creates the refund.

--- a/src/conekta/OrderContext.cs
+++ b/src/conekta/OrderContext.cs
@@ -178,6 +178,31 @@ namespace Conekta
       throw new ConektaException(await response.Content.ReadAsStringAsync());
     }
 
+    /// <summary>
+    /// Cancel the specified orderId.
+    /// (For Oxxo payments only)
+    /// </summary>
+    /// <returns>The canceled order.</returns>
+    /// <param name="orderId">Order identifier.</param>
+    public async Task<Order> CancelAsync(string orderId)
+    {
+      if (orderId is null)
+      {
+        throw new ArgumentNullException(nameof(orderId));
+      }
+
+      var response = await _httpRequestFactory.SendAsync(HttpMethod.Post, $"{RESOURCEURI}/{orderId}/cancel", "{}");
+
+      //Console.WriteLine($"======= {response.StatusCode}, {await response.Content.ReadAsStringAsync()}");
+
+      if (response.IsSuccessStatusCode)
+      {
+        return response.ContentAsType<Order>();
+      }
+
+      throw new ConektaException(await response.Content.ReadAsStringAsync());
+    }
+
 
     /// <summary>
     /// Creates the refund.

--- a/tests/Conekta.Integration.Tests/OrderTests.cs
+++ b/tests/Conekta.Integration.Tests/OrderTests.cs
@@ -73,7 +73,7 @@ namespace Conekta.Integration.Tests
     };
 
     /// <summary>
-    /// Custormer Info.
+    /// Customer Info.
     /// </summary>
     private readonly CustomerInfo _customerInfo = new CustomerInfo
     {
@@ -405,6 +405,34 @@ namespace Conekta.Integration.Tests
       var charge = orderCaptured.ChargeList.Data.FirstOrDefault();
 
       charge.Status.Should().Be("paid");
+    }
+
+    /// <summary>
+    /// Cancel OK
+    /// </summary>
+    /// <returns></returns>
+    [Fact]
+    public async Task CancelAsync_OK_Test()
+    {
+      var orderToCancel = (OrderOperationData)_validOrder.Clone();
+
+      orderToCancel.PreAuthorize = true;
+      orderToCancel.CustomerInfo = _customerInfo;
+      orderToCancel.Charges = new List<ChargeOperationData>
+      {
+        _validChargeOxxo
+      };
+
+      var orderCreated = await _orderContext.CreateAsync(orderToCancel);
+
+      var orderCanceled = await _orderContext.CancelAsync(orderCreated.Id);
+
+      Console.WriteLine(@$"CancelAsync_OK_Test    [->] { JsonConvert.SerializeObject(orderCanceled,
+        Formatting.Indented) }");
+
+      var charge = orderCanceled.ChargeList.Data.FirstOrDefault();
+      
+      charge.Status.Should().Be("canceled");
     }
 
     /// <summary>


### PR DESCRIPTION
### **Description:**

It was needed to implement the canceled method to update OXXO payments to expire them

### **Changes proposed:**

 - Add missing method calling the `/cancel` endpoint

### **How to test it:**
Execute the following command:

`dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./lcov.info /p:Exclude="[xunit*]*"`
