### PR TITLE
Find order by oxxo reference method creation for Oxxo charges

### DIFF
--- a/src/conekta/IOrderContext.cs
+++ b/src/conekta/IOrderContext.cs
@@ -32,6 +32,13 @@ namespace Conekta
     /// <param name="orderId">Order identifier.</param>
     Task<Order> FindAsync(string orderId);
 
+	/// <summary>
+    /// Search the async by specific params.
+    /// </summary>
+    /// <returns>The async.</returns>
+    /// <param name="data">Data for the search.</param>
+    Task<OrderList> SearchAsync(string reference); 
+
     /// <summary>
     /// Wheres the async.
     /// </summary>

--- a/src/conekta/OrderContext.cs
+++ b/src/conekta/OrderContext.cs
@@ -127,6 +127,28 @@ namespace Conekta
 
       throw new ConektaException(await response.Content.ReadAsStringAsync());
     }
+    
+    /// <summary>
+    /// Search the async by specific params.
+    /// </summary>
+    /// <returns>The async.</returns>
+    /// <param name="data">Data for the search.</param>
+    public async Task<OrderList> SearchAsync(string data)
+    {
+
+      var url = $"?expand=last_payment_info&search={data}";
+
+      var response = await _httpRequestFactory.SendAsync(HttpMethod.Get, $"{RESOURCEURI}{url}");
+
+      //Console.WriteLine($"======= {response.StatusCode}, {await response.Content.ReadAsStringAsync()}");
+
+      if (response.IsSuccessStatusCode)
+      {
+        return response.ContentAsType<OrderList>();
+      }
+
+      throw new ConektaException(await response.Content.ReadAsStringAsync());
+    }
 
     /// <summary>
     /// Wheres the async.

--- a/tests/Conekta.Integration.Tests/OrderTests.cs
+++ b/tests/Conekta.Integration.Tests/OrderTests.cs
@@ -356,6 +356,96 @@ namespace Conekta.Integration.Tests
 
       test.Should().BeTrue();
     }
+    
+    /// <summary>
+    /// Search by customer email OK.
+    /// </summary>
+    /// <returns></returns>
+    [Fact]
+    public async Task SearchAsync_CustomerEmail_OK_Test()
+    {
+  
+      var orderToCancel = (OrderOperationData)_validOrder.Clone();
+
+      orderToCancel.PreAuthorize = true;
+      orderToCancel.CustomerInfo = _customerInfo;
+      orderToCancel.Charges = new List<ChargeOperationData>
+      {
+        _validChargeOxxo
+      };
+
+      var orderCreated = await _orderContext.CreateAsync(orderToCancel);
+
+      var ordersFound = await _orderContext.SearchAsync(_customerInfo.Email);
+
+      //Console.WriteLine(@$"WhereAsync_OK_Test    [->] { JsonConvert.SerializeObject(ordersFound,
+      //  Formatting.Indented) }");
+
+  
+      ordersFound.Data.Count.Should().NotBe(0);
+      ordersFound.Data.FirstOrDefault().ChargeList.Data.Count.Should().NotBe(0);
+    }
+    
+    /// <summary>
+    /// Search by customer email OK.
+    /// </summary>
+    /// <returns></returns>
+    [Fact]
+    public async Task SearchAsync_CustomerName_OK_Test()
+    {
+  
+      var orderToCancel = (OrderOperationData)_validOrder.Clone();
+
+      orderToCancel.PreAuthorize = true;
+      orderToCancel.CustomerInfo = _customerInfo;
+      orderToCancel.Charges = new List<ChargeOperationData>
+      {
+        _validChargeOxxo
+      };
+
+      var ordersFound = await _orderContext.SearchAsync(_customerInfo.Name);
+
+      //Console.WriteLine(@$"WhereAsync_OK_Test    [->] { JsonConvert.SerializeObject(ordersFound,
+      //  Formatting.Indented) }");
+
+  
+      ordersFound.Data.Count.Should().NotBe(0);
+      ordersFound.Data.FirstOrDefault().ChargeList.Data.Count.Should().NotBe(0);
+    }
+    
+    /// <summary>
+    /// Search by reference OK.
+    /// </summary>
+    /// <returns></returns>
+    [Fact]
+    public async Task SearchAsync_PaymentReference_OK_Test()
+    {
+  
+      var orderToCancel = (OrderOperationData)_validOrder.Clone();
+
+      orderToCancel.PreAuthorize = true;
+      orderToCancel.CustomerInfo = _customerInfo;
+      orderToCancel.Charges = new List<ChargeOperationData>
+      {
+        _validChargeOxxo
+      };
+
+      var orderCreated = await _orderContext.CreateAsync(orderToCancel);
+
+      var createdReference = orderCreated.ChargeList.Data.FirstOrDefault().PaymentMethod.Reference;
+      
+      var ordersFound = await _orderContext.SearchAsync(createdReference);
+
+      //Console.WriteLine(@$"WhereAsync_OK_Test    [->] { JsonConvert.SerializeObject(ordersFound,
+      //  Formatting.Indented) }");
+
+  
+      ordersFound.Data.Count.Should().NotBe(0);
+      ordersFound.Data.FirstOrDefault().ChargeList.Data.Count.Should().NotBe(0);
+      var chargeFound = ordersFound.Data.FirstOrDefault().ChargeList.Data.FirstOrDefault();
+      chargeFound.PaymentMethod.Reference.Should().Be(createdReference);
+
+    }
 
     /// <summary>
     /// Where Ok.


### PR DESCRIPTION
### **Description:**

It was needed to implement a method to find OXXO payments by their oxxo reference

### **Changes proposed:**

 - Add missing method `SearchAsync` calling the `/orders` endpoint with the reference query string. This allows to make some more queries over the order.

### **How to test it:**
Execute the following command:

`dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./lcov.info /p:Exclude="[xunit*]*"`
