### PR TITLE
Add the refund data model to the general order model.

### DIFF
--- a/src/conekta/Models/Charge.cs
+++ b/src/conekta/Models/Charge.cs
@@ -84,6 +84,13 @@ namespace Conekta.Models
     /// </summary>
     [JsonProperty(PropertyName = "order_id")]
     public string OrderId { get; private set; }
+    
+    /// <summary>
+    /// Gets or sets the referenceId.
+    /// </summary>
+    /// <value>The referenceId.</value>
+    [JsonProperty(PropertyName = "reference_id")]
+    public string ReferenceId { get; set;}
 
     /// <summary>
     /// 

--- a/src/conekta/Models/ChargeOperationData.cs
+++ b/src/conekta/Models/ChargeOperationData.cs
@@ -29,7 +29,14 @@ namespace Conekta.Models
     /// <value>The payment method.</value>
     [JsonProperty(PropertyName = "payment_method")]
     public PaymentMethod PaymentMethod { get; set; }
-
+    
+    /// <summary>
+    /// Gets or sets the refunds.
+    /// </summary>
+    /// <value>The refunds.</value>
+    [JsonProperty(PropertyName = "refunds")]
+    public RefundsList Refunds { get; set; }
+    
     #endregion
   }
 }

--- a/src/conekta/Models/RefundsList.cs
+++ b/src/conekta/Models/RefundsList.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Conekta.Models
+{
+    /// <summary>
+    /// Refunds list.
+    /// </summary>
+    public class RefundsList : ModelListBase
+    {
+        #region :: Properties ::
+
+        /// <summary>
+        /// Gets or sets the data.
+        /// </summary>
+        /// <value>The data.</value>
+        [JsonProperty(PropertyName = "data")]
+        public List<RefundsOperationData> Data { get; set; }
+
+        #endregion
+    }
+}

--- a/src/conekta/Models/RefundsOperationData.cs
+++ b/src/conekta/Models/RefundsOperationData.cs
@@ -1,0 +1,44 @@
+using Newtonsoft.Json;
+
+namespace Conekta.Models
+{
+    /// <summary>
+    /// Refunds operation data.
+    /// </summary>
+    public class RefundsOperationData
+    {
+        /// <summary>
+        /// Gets or sets the identifier.
+        /// </summary>
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of the object.
+        /// </summary>
+        /// <value>The type of the object.</value>
+        [JsonProperty(PropertyName = "object")]
+        public string ObjectType { get; set; }
+        
+        /// <summary>
+        /// Gets the amount.
+        /// </summary>
+        /// <value>The amount.</value>
+        [JsonProperty(PropertyName = "amount")]
+        public int Amount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the auth code.
+        /// </summary>
+        /// <value>The auth code.</value>
+        [JsonProperty(PropertyName = "auth_code")]
+        public string AuthCode { get; set; }
+
+        /// <summary>
+        /// Gets the creation date.
+        /// </summary>
+        [JsonProperty(PropertyName = "created_at")]
+        public long CreatedAt { get; private set; }
+
+    }
+}

--- a/tests/Conekta.Integration.Tests/OrderTests.cs
+++ b/tests/Conekta.Integration.Tests/OrderTests.cs
@@ -554,6 +554,8 @@ namespace Conekta.Integration.Tests
         Formatting.Indented) }");
 
       orderRefunded.PaymentStatus.Should().Be("refunded");
+      orderRefunded.ChargeList.Data[0].Refunds.Data[0].ObjectType.Should().Be("refund");
+      orderRefunded.ChargeList.Data[0].Refunds.Data[0].Amount.Should().Be(-35000);
     }
 
     /// <summary>


### PR DESCRIPTION
## Description:
It was needed to add the refunds data model to the Order model.

## Changes proposed:

Add missing parameters to the order model.

## How to test it:
Execute the following command:

dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./lcov.info /p:Exclude="[xunit*]*"