### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,8 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/conekta/conekta-.net/security/code-scanning/3](https://github.com/conekta/conekta-.net/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root (top-level, alongside `name` and `on`) so all jobs inherit least-privilege defaults unless overridden.  
For this workflow, the best minimal setting is:

- `contents: read`

This preserves current functionality for checkout/build/test while limiting token scope.  
Edit `.github/workflows/dotnet.yml` by inserting the block between the trigger section and `jobs:`.

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
